### PR TITLE
Add support for semaphores with deep debugging

### DIFF
--- a/dmtcp/CMakeLists.txt
+++ b/dmtcp/CMakeLists.txt
@@ -37,6 +37,7 @@ set(MCMINI_CPP_SRC
   src/mcmini/model/transition_sequence.cpp
   src/mcmini/model/transitions/mutex.cpp
   src/mcmini/model/transitions/thread.cpp
+  src/mcmini/model/transitions/semaphore.cpp
   src/mcmini/model_checking/algorithms/classic_dpor.cpp
   src/mcmini/model_checking/algorithms/clock_vector.cpp
   src/mcmini/real_world/dmtcp_process_source.cpp
@@ -59,6 +60,7 @@ set(LIBMCMINI_C_SRC
   src/lib/log.c
   src/lib/main.c
   src/lib/record.c
+  src/lib/sem-wrappers.c
   src/lib/template/loop.c
   src/lib/template/sig.c
   src/lib/wrappers.c

--- a/dmtcp/CMakeLists.txt
+++ b/dmtcp/CMakeLists.txt
@@ -34,6 +34,7 @@ set(MCMINI_CPP_SRC
   src/mcmini/model/diff_state.cpp
   src/mcmini/model/program.cpp
   src/mcmini/model/state_sequence.cpp
+  src/mcmini/model/transition_registry.cpp
   src/mcmini/model/transition_sequence.cpp
   src/mcmini/model/transitions/mutex.cpp
   src/mcmini/model/transitions/thread.cpp

--- a/dmtcp/include/mcmini/defines.h
+++ b/dmtcp/include/mcmini/defines.h
@@ -33,7 +33,8 @@ typedef uint64_t trid_t;
 #define RUNNER_ID_MAX UINT16_MAX
 #define RID_MAIN_THREAD ((runner_id_t)0)
 #define RID_INVALID ((runner_id_t)-1)
-#define RID_PTHREAD_CREATE_FAILED ((runner_id_t)-2)
+#define RID_CHECKPOINT_THREAD ((runner_id_t)-2)
+#define RID_PTHREAD_CREATE_FAILED ((runner_id_t)-3)
 
 #define FORK_IS_CHILD_PID(pid) ((pid) == 0)
 #define FORK_IS_PARENT_PID(pid) (!(FORK_IS_CHILD_PID(pid)))

--- a/dmtcp/include/mcmini/model/objects/semaphore.hpp
+++ b/dmtcp/include/mcmini/model/objects/semaphore.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+
+#include "mcmini/misc/extensions/unique_ptr.hpp"
+#include "mcmini/model/visible_object_state.hpp"
+
+namespace model {
+namespace objects {
+struct semaphore : public model::visible_object_state {
+ private:
+  unsigned _count = 0;
+  enum state { uninitialized, initialized, destroyed };
+
+ private:
+  state current_state = state::uninitialized;
+
+ public:
+  semaphore() = default;
+  ~semaphore() = default;
+  semaphore(const semaphore &) = default;
+  explicit semaphore(unsigned count)
+      : _count(count), current_state(initialized) {}
+  void wait() { this->_count--; }
+  void post() { this->_count++; }
+  unsigned count() const { return this->_count; }
+  bool will_block() const { return this->_count <= 0; }
+  std::unique_ptr<visible_object_state> clone() const override {
+    return extensions::make_unique<semaphore>(*this);
+  }
+  std::string to_string() const override {
+    return "semaphore(count: " + std::to_string(_count) + ")";
+  }
+};
+}  // namespace objects
+}  // namespace model

--- a/dmtcp/include/mcmini/model/objects/semaphore.hpp
+++ b/dmtcp/include/mcmini/model/objects/semaphore.hpp
@@ -8,21 +8,24 @@
 namespace model {
 namespace objects {
 struct semaphore : public model::visible_object_state {
- private:
-  unsigned _count = 0;
+ public:
   enum state { uninitialized, initialized, destroyed };
 
  private:
+  unsigned _count = 0;
   state current_state = state::uninitialized;
 
  public:
   semaphore() = default;
   ~semaphore() = default;
   semaphore(const semaphore &) = default;
-  explicit semaphore(unsigned count)
-      : _count(count), current_state(initialized) {}
+  explicit semaphore(state s) : semaphore(s, 0) {}
+  explicit semaphore(unsigned count) : semaphore(initialized, count) {}
+  explicit semaphore(state s, unsigned count)
+      : _count(count), current_state(s) {}
   void wait() { this->_count--; }
   void post() { this->_count++; }
+  void destroy() { this->current_state = state::destroyed; }
   unsigned count() const { return this->_count; }
   bool will_block() const { return this->_count <= 0; }
   std::unique_ptr<visible_object_state> clone() const override {

--- a/dmtcp/include/mcmini/model/program.hpp
+++ b/dmtcp/include/mcmini/model/program.hpp
@@ -58,6 +58,7 @@ class program {
           pending_transitions &&initial_first_steps);
   program(program &&) = default;
   program(const program &) = delete;
+  static program starting_from_main();
 
   std::unordered_set<runner_id_t> get_enabled_runners() const;
   size_t get_num_runners() const { return next_steps.size(); }

--- a/dmtcp/include/mcmini/model/transition_registry.hpp
+++ b/dmtcp/include/mcmini/model/transition_registry.hpp
@@ -29,6 +29,7 @@ class transition_registry final {
   using transition_discovery_callback =
       transition *(*)(state::runner_id_t, const volatile runner_mailbox &,
                       model_to_system_map &);
+  static transition_registry default_registry();
 
   /**
    * @brief Marks the specified transition subclass as possible to encounter at

--- a/dmtcp/include/mcmini/model/transitions/semaphore/callbacks.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/callbacks.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "mcmini/coordinator/model_to_system_map.hpp"
+#include "mcmini/model/state.hpp"
+#include "mcmini/real_world/mailbox/runner_mailbox.h"
+
+model::transition* sem_init_callback(runner_id_t,
+                                     const volatile runner_mailbox&,
+                                     model_to_system_map&);
+model::transition* sem_post_callback(runner_id_t,
+                                     const volatile runner_mailbox&,
+                                     model_to_system_map&);
+model::transition* sem_wait_callback(runner_id_t,
+                                     const volatile runner_mailbox&,
+                                     model_to_system_map&);

--- a/dmtcp/include/mcmini/model/transitions/semaphore/callbacks.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/callbacks.hpp
@@ -13,3 +13,6 @@ model::transition* sem_post_callback(runner_id_t,
 model::transition* sem_wait_callback(runner_id_t,
                                      const volatile runner_mailbox&,
                                      model_to_system_map&);
+model::transition* sem_destroy_callback(runner_id_t,
+                                        const volatile runner_mailbox&,
+                                        model_to_system_map&);

--- a/dmtcp/include/mcmini/model/transitions/semaphore/sem_destroy.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/sem_destroy.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "mcmini/model/objects/semaphore.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace model {
+namespace transitions {
+
+struct sem_destroy : public model::transition {
+ private:
+  const state::objid_t sem_id;
+
+ public:
+  sem_destroy(runner_id_t executor, state::objid_t sem_id)
+      : transition(executor), sem_id(sem_id), count(count) {}
+  ~sem_destroy() = default;
+  status modify(model::mutable_state& s) const override {
+    using namespace model::objects;
+    s.add_state_for_obj(sem_id, new semaphore(semaphore::destroyed));
+    return status::exists;
+  }
+  state::objid_t get_id() const { return this->sem_id; }
+  std::string to_string() const override {
+    return "sem_init(semaphore:" + std::to_string(sem_id) + ")";
+  }
+};
+}  // namespace transitions
+}  // namespace model

--- a/dmtcp/include/mcmini/model/transitions/semaphore/sem_init.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/sem_init.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "mcmini/model/objects/semaphore.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace model {
+namespace transitions {
+
+struct sem_init : public model::transition {
+ private:
+  const state::objid_t sem_id;
+  unsigned count = 0;
+
+ public:
+  sem_init(runner_id_t executor, state::objid_t sem_id)
+      : sem_init(executor, sem_id, 0) {}
+  sem_init(runner_id_t executor, state::objid_t sem_id, unsigned count)
+      : transition(executor), sem_id(sem_id), count(count) {}
+  ~sem_init() = default;
+  status modify(model::mutable_state& s) const override {
+    using namespace model::objects;
+    s.add_state_for_obj(sem_id, new semaphore(count));
+    return status::exists;
+  }
+  state::objid_t get_id() const { return this->sem_id; }
+  std::string to_string() const override {
+    return "sem_init(semaphore:" + std::to_string(sem_id) + ")";
+  }
+};
+}  // namespace transitions
+}  // namespace model

--- a/dmtcp/include/mcmini/model/transitions/semaphore/sem_post.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/sem_post.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "mcmini/model/objects/semaphore.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace model {
+namespace transitions {
+
+struct sem_post : public model::transition {
+ private:
+  const state::objid_t sem_id;
+
+ public:
+  sem_post(runner_id_t executor, state::objid_t sem_id)
+      : transition(executor), sem_id(sem_id) {}
+  ~sem_post() = default;
+  status modify(model::mutable_state& s) const override {
+    using namespace model::objects;
+    const semaphore* sem = s.get_state_of_object<semaphore>(sem_id);
+    s.add_state_for_obj(sem_id, new semaphore(sem->count() + 1));
+    return status::exists;
+  }
+  state::objid_t get_id() const { return this->sem_id; }
+  std::string to_string() const override {
+    return "sem_post(semaphore:" + std::to_string(sem_id) + ")";
+  }
+};
+}  // namespace transitions
+}  // namespace model

--- a/dmtcp/include/mcmini/model/transitions/semaphore/sem_wait.hpp
+++ b/dmtcp/include/mcmini/model/transitions/semaphore/sem_wait.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "mcmini/model/objects/semaphore.hpp"
+#include "mcmini/model/transition.hpp"
+
+namespace model {
+namespace transitions {
+
+struct sem_wait : public model::transition {
+ private:
+  const state::objid_t sem_id;
+
+ public:
+  sem_wait(runner_id_t executor, state::objid_t sem_id)
+      : transition(executor), sem_id(sem_id) {}
+  ~sem_wait() = default;
+  status modify(model::mutable_state& s) const override {
+    using namespace model::objects;
+    const semaphore* sem = s.get_state_of_object<semaphore>(sem_id);
+    if (sem->will_block()) {
+      return status::disabled;
+    }
+    s.add_state_for_obj(sem_id, new semaphore(sem->count() - 1));
+    return status::exists;
+  }
+  state::objid_t get_id() const { return this->sem_id; }
+  std::string to_string() const override {
+    return "sem_wait(semaphore:" + std::to_string(sem_id) + ")";
+  }
+};
+}  // namespace transitions
+}  // namespace model

--- a/dmtcp/include/mcmini/model_checking/algorithms/classic_dpor.hpp
+++ b/dmtcp/include/mcmini/model_checking/algorithms/classic_dpor.hpp
@@ -26,11 +26,11 @@ class classic_dpor final : public algorithm {
     callbacks no_callbacks;
     this->verify_using(coordinator, no_callbacks);
   }
-
-  classic_dpor() : classic_dpor(dependency_relation_type()) {}
+  static dependency_relation_type default_dependencies();
+  static coenabled_relation_type default_coenabledness();
   classic_dpor(
-      dependency_relation_type dependency_relation,
-      coenabled_relation_type coenabled_relation = coenabled_relation_type())
+      dependency_relation_type dependency_relation = default_dependencies(),
+      coenabled_relation_type coenabled_relation = default_coenabledness())
       : dependency_relation(std::move(dependency_relation)),
         coenabled_relation(std::move(coenabled_relation)) {}
 

--- a/dmtcp/include/mcmini/real_world/process/local_linux_process.hpp
+++ b/dmtcp/include/mcmini/real_world/process/local_linux_process.hpp
@@ -21,11 +21,13 @@ namespace real_world {
 class local_linux_process : public process {
  private:
   pid_t pid;
+  bool should_wait; /* Whether `wait(3)` should be called on destruction */
 
  public:
   pid_t get_pid() const override { return pid; }
   local_linux_process() : local_linux_process(-1) {}
-  local_linux_process(pid_t pid);
+  local_linux_process(pid_t pid) : local_linux_process(pid, true) {}
+  local_linux_process(pid_t pid, bool should_wait);
   local_linux_process(const local_linux_process&) = delete;
   local_linux_process(local_linux_process&&);
   local_linux_process& operator=(const local_linux_process&) = delete;

--- a/dmtcp/include/mcmini/real_world/process/template_process.h
+++ b/dmtcp/include/mcmini/real_world/process/template_process.h
@@ -6,6 +6,7 @@ extern "C" {
 
 #include <semaphore.h>
 #include <signal.h>
+#include <stdbool.h>
 
 #define TEMPLATE_FORK_FAILED (-2)  // fork(2) failed in the template
 
@@ -34,11 +35,6 @@ struct template_process_t {
 
   // MARK: DMTCP ONLY
 };
-
-// The VIRTUAL tid of the checkpoint thread
-// as it appeared at record-time
-extern pthread_t ckpt_pthread_descriptor;
-extern pid_t multithreaded_fork(void);
 
 #ifdef __cplusplus
 }

--- a/dmtcp/include/mcmini/spy/checkpointing/objects.h
+++ b/dmtcp/include/mcmini/spy/checkpointing/objects.h
@@ -31,6 +31,7 @@ typedef enum thread_status {
 typedef enum semaphore_status {
   SEM_UNINITIALIZED,
   SEM_INITIALIZED,
+  SEM_DESTROYED,
 } semaphore_status;
 
 typedef struct semaphore_state {

--- a/dmtcp/include/mcmini/spy/checkpointing/objects.h
+++ b/dmtcp/include/mcmini/spy/checkpointing/objects.h
@@ -34,7 +34,7 @@ typedef enum semaphore_status {
 } semaphore_status;
 
 typedef struct semaphore_state {
-  int count;
+  unsigned count;
   semaphore_status status;
 } semaphore_state;
 

--- a/dmtcp/include/mcmini/spy/checkpointing/record.h
+++ b/dmtcp/include/mcmini/spy/checkpointing/record.h
@@ -50,6 +50,15 @@ extern "C" {
  * behave as in `PRE_DMTCP_INIT`. For `pthread_create`, the call is _only_
  * forwarded into DMTCP instead -- the checkpoint thread is NOT recorded.
  *
+ * CHECKPOINT_THREAD:
+ *   In this mode, DMTCP has created the checkpoint thread. The checkpoint
+ * thread should not interact with McMini in any way, but the two interact
+ * because the functions `libmcmini.so` overrides are used by `dmtcp`
+ * extensively (e.g. `sem_wait()`). This mode, special to the library when
+ * executing from the perspective of the checkpoint thread, indicates that DMTCP
+ * has called directly into McMini. In most cases, this probably means
+ * forwarding the call to DMTCP's wrapper functions of to `libpthread.so`.
+ *
  * RECORD:
  *   In this mode, `libmcmini.so` performs a light-weight recording of the
  * primitives it encounters and keeps track of their state. Only after doing so
@@ -105,6 +114,7 @@ extern "C" {
 enum libmcmini_mode {
   PRE_DMTCP_INIT,
   PRE_CHECKPOINT_THREAD,
+  CHECKPOINT_THREAD,
   RECORD,
   PRE_CHECKPOINT,
   DMTCP_RESTART_INTO_BRANCH,

--- a/dmtcp/include/mcmini/spy/checkpointing/record.h
+++ b/dmtcp/include/mcmini/spy/checkpointing/record.h
@@ -10,6 +10,16 @@ extern "C" {
 #include <stdatomic.h>
 #endif
 
+#ifndef ATOMIC_BOOL_LOCK_FREE
+#error \
+    "Atomic booleans must be lock free, but the compiler has indicated this is not the case"
+#endif
+
+#ifndef ATOMIC_INT_LOCK_FREE
+#error \
+    "Atomic integers must be lock free, but the compiler has indicated this is not the case"
+#endif
+
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdbool.h>
@@ -142,17 +152,24 @@ enum libmcmini_mode {
  * to acquire the lock, we'd have deadlock.
  */
 extern volatile atomic_int libmcmini_mode;
+
 bool is_in_restart_mode(void);
 enum libmcmini_mode get_current_mode();
 void set_current_mode(enum libmcmini_mode);
+
+extern pthread_t ckpt_pthread_descriptor;
+extern volatile atomic_bool libmcmini_has_recorded_checkpoint_thread;
+bool is_checkpoint_thread(void);
 
 typedef struct visible_object visible_object;
 typedef struct rec_list rec_list;
 
 extern sem_t dmtcp_restart_sem;
-extern rec_list *head_record_mode;
-extern rec_list *current_record_mode;
 extern pthread_mutex_t rec_list_lock;
+extern pthread_mutex_t dmtcp_list_lock;
+extern rec_list *head_record_mode;
+// The VIRTUAL tid of the checkpoint thread
+// as it appeared while recording.
 
 /// @brief Retrieves the stored state for the given object
 /// @return a pointer to the node in the list formed by `head`,
@@ -162,12 +179,15 @@ extern pthread_mutex_t rec_list_lock;
 rec_list *find_object(void *addr, rec_list *);
 rec_list *find_thread_record_mode(pthread_t);
 rec_list *find_object_record_mode(void *addr);
+rec_list *find_dmtcp_object(void *addr);
+bool is_dmtcp_object(void *addr);
 
 /// @brief Adds a new element to the list `head`.
 ///
 /// @note you must acquire `rec_list_lock` before calling this function
 rec_list *add_rec_entry(const visible_object *, rec_list **, rec_list **);
 rec_list *add_rec_entry_record_mode(const visible_object *);
+rec_list *add_dmctp_object(const visible_object *);
 
 /**
  * @brief Notifies the template thread spawned during DMTCP_RESTART
@@ -181,6 +201,9 @@ void notify_template_thread();
  * be awoken.
  */
 void thread_wait_after_dmtcp_restart();
+
+// Spawns a new process with all threads of this process duplicated.
+pid_t multithreaded_fork(void);
 
 #ifdef __cplusplus
 }

--- a/dmtcp/include/mcmini/spy/checkpointing/transitions.h
+++ b/dmtcp/include/mcmini/spy/checkpointing/transitions.h
@@ -22,9 +22,6 @@ typedef enum transition_type {
   SEM_WAIT_TYPE,
   SEM_POST_TYPE,
   SEM_DESTROY_TYPE
-  // sem_init,
-  // sem_wait,
-  // sem_post,
   // thread_create,
   // thread_join
   //...

--- a/dmtcp/include/mcmini/spy/intercept/interception.h
+++ b/dmtcp/include/mcmini/spy/intercept/interception.h
@@ -38,9 +38,11 @@ int libpthread_mutex_destroy(pthread_mutex_t *);
 int sem_init(sem_t*, int, unsigned);
 int sem_post(sem_t*);
 int sem_wait(sem_t*);
+int sem_destroy(sem_t *);
 int libpthread_sem_init(sem_t*, int, int);
 int libpthread_sem_post(sem_t*);
 int libpthread_sem_wait(sem_t*);
+int libpthread_sem_destroy(sem_t *);
 int libpthread_sem_timedwait(sem_t*, struct timespec *);
 
 unsigned sleep(unsigned);

--- a/dmtcp/include/mcmini/spy/intercept/interception.h
+++ b/dmtcp/include/mcmini/spy/intercept/interception.h
@@ -34,6 +34,10 @@ int libpthread_mutex_timedlock(pthread_mutex_t *, struct timespec *);
 int libpthread_mutex_unlock(pthread_mutex_t *);
 int libpthread_mutex_destroy(pthread_mutex_t *);
 
+
+int sem_init(sem_t*, int, unsigned);
+int sem_post(sem_t*);
+int sem_wait(sem_t*);
 int libpthread_sem_init(sem_t*, int, int);
 int libpthread_sem_post(sem_t*);
 int libpthread_sem_wait(sem_t*);

--- a/dmtcp/include/mcmini/spy/intercept/wrappers.h
+++ b/dmtcp/include/mcmini/spy/intercept/wrappers.h
@@ -23,6 +23,7 @@ int mc_pthread_join(pthread_t, void**);
 int mc_sem_init(sem_t*, int, unsigned);
 int mc_sem_post(sem_t*);
 int mc_sem_wait(sem_t*);
+int mc_sem_destroy(sem_t *sem);
 unsigned mc_sleep(unsigned);
 
 /*

--- a/dmtcp/include/mcmini/spy/intercept/wrappers.h
+++ b/dmtcp/include/mcmini/spy/intercept/wrappers.h
@@ -8,6 +8,7 @@
 void thread_await_scheduler(void);
 void thread_wake_scheduler_and_wait(void);
 void thread_awake_scheduler_for_thread_finish_transition(void);
+void thread_handle_after_dmtcp_restart(void);
 volatile runner_mailbox *thread_get_mailbox(void);
 
 int mc_pthread_mutex_init(pthread_mutex_t *mutex,
@@ -16,10 +17,12 @@ int mc_pthread_mutex_lock(pthread_mutex_t *mutex);
 int mc_pthread_mutex_unlock(pthread_mutex_t *mutex);
 int mc_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                     void *(*routine)(void *), void *arg);
-int mc_sem_init(sem_t *, int, int);
 int mc_sem_post(sem_t *);
 int mc_sem_wait(sem_t *);
 int mc_pthread_join(pthread_t, void**);
+int mc_sem_init(sem_t*, int, unsigned);
+int mc_sem_post(sem_t*);
+int mc_sem_wait(sem_t*);
 unsigned mc_sleep(unsigned);
 
 /*

--- a/dmtcp/src/common/runner_mailbox.c
+++ b/dmtcp/src/common/runner_mailbox.c
@@ -22,8 +22,13 @@ void mc_runner_mailbox_init(volatile runner_mailbox* r) {
 
 void mc_runner_mailbox_destroy(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
+#ifdef MC_SHARED_LIBRARY
+  libpthread_sem_destroy(&ref->model_side_sem);
+  libpthread_sem_destroy(&ref->child_side_sem);
+#else
   sem_destroy(&ref->model_side_sem);
   sem_destroy(&ref->child_side_sem);
+#endif
 }
 
 int mc_wait_for_thread(volatile runner_mailbox* r) {

--- a/dmtcp/src/common/runner_mailbox.c
+++ b/dmtcp/src/common/runner_mailbox.c
@@ -5,12 +5,18 @@
 
 #include "mcmini/lib/log.h"
 #include "mcmini/defines.h"
+#include "mcmini/spy/intercept/interception.h"
 #include "string.h"
 
 void mc_runner_mailbox_init(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
+#ifdef MC_SHARED_LIBRARY
+  libpthread_sem_init(&ref->model_side_sem, SEM_FLAG_SHARED, 0);
+  libpthread_sem_init(&ref->child_side_sem, SEM_FLAG_SHARED, 0);
+#else
   sem_init(&ref->model_side_sem, SEM_FLAG_SHARED, 0);
   sem_init(&ref->child_side_sem, SEM_FLAG_SHARED, 0);
+#endif
   memset(ref->cnts, 0, sizeof(ref->cnts));
 }
 
@@ -23,35 +29,35 @@ void mc_runner_mailbox_destroy(volatile runner_mailbox* r) {
 int mc_wait_for_thread(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
 #ifdef MC_SHARED_LIBRARY
-  printf("mc_wait_for_thread: sem_wait(%p)\n", &ref->model_side_sem);
-  fflush(stdout);
-#endif
+  return libpthread_sem_wait(&ref->model_side_sem);
+#else
   return sem_wait(&ref->model_side_sem);
+#endif
 }
 
 int mc_wait_for_scheduler(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
 #ifdef MC_SHARED_LIBRARY
-  printf("mc_wait_for_scheduler: sem_wait(%p)\n", &ref->child_side_sem);
-  fflush(stdout);
-#endif
+  return libpthread_sem_wait(&ref->child_side_sem);
+#else
   return sem_wait(&ref->child_side_sem);
+#endif
 }
 
 int mc_wake_thread(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
 #ifdef MC_SHARED_LIBRARY
-  printf("mc_wake_thread: sem_post(%p)\n", &ref->child_side_sem);
-  fflush(stdout);
-#endif
+  return libpthread_sem_post(&ref->child_side_sem);
+#else
   return sem_post(&ref->child_side_sem);
+#endif
 }
 
 int mc_wake_scheduler(volatile runner_mailbox* r) {
   runner_mailbox_ref ref = (runner_mailbox_ref)(r);
 #ifdef MC_SHARED_LIBRARY
-  printf("mc_wake_scheduler: sem_post(%p)\n", &ref->model_side_sem);
-  fflush(stdout);
-#endif
+  return libpthread_sem_post(&ref->model_side_sem);
+#else
   return sem_post(&ref->model_side_sem);
+#endif
 }

--- a/dmtcp/src/examples/CMakeLists.txt
+++ b/dmtcp/src/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(hello-world hello-world.c)
 add_executable(deadly-embrace deadly-embrace.c)
 add_executable(fifo-example fifo.cpp)
+add_executable(producer-consumer producer-consumer.c)
 target_link_libraries(hello-world PUBLIC -pthread)
 target_link_libraries(deadly-embrace PUBLIC -pthread)
+target_link_libraries(producer-consumer PUBLIC -pthread)

--- a/dmtcp/src/examples/producer-consumer.c
+++ b/dmtcp/src/examples/producer-consumer.c
@@ -56,14 +56,9 @@ void *consumer(void *cno)
 
 int main(int argc, char* argv[])
 {
-    if (argc < 4) {
-      printf("Usage: %s <NUM_PRODUCERS> <NUM_CONSUMERS> <DEBUG>\n", argv[0]);
-      return 1;
-    }
-
-    int NUM_PRODUCERS = atoi(argv[1]);
-    int NUM_CONSUMERS = atoi(argv[2]);
-    DEBUG = atoi(argv[3]);
+    int NUM_PRODUCERS = 1;
+    int NUM_CONSUMERS = 1;
+    DEBUG = 1;
 
     pthread_t pro[NUM_PRODUCERS],con[NUM_CONSUMERS];
 

--- a/dmtcp/src/examples/producer-consumer.c
+++ b/dmtcp/src/examples/producer-consumer.c
@@ -1,0 +1,93 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <unistd.h>
+
+#define MaxItems 1
+#define BufferSize 2
+
+sem_t empty;
+sem_t full;
+int in = 0;
+int out = 0;
+int buffer[BufferSize];
+pthread_mutex_t mutex;
+int DEBUG;
+
+void *producer(void *pno)
+{
+    int item;
+    for(int i = 0; i < MaxItems; i++) {
+        sleep(3);
+        item = rand(); // Produce an random item
+        sem_wait(&empty);
+        pthread_mutex_lock(&mutex);
+        buffer[in] = item;
+        if (DEBUG) {
+          printf("Producer %d: Insert Item %d at %d\n",
+                 *((int *)pno),buffer[in],in);
+        }
+        in = (in+1)%BufferSize;
+        pthread_mutex_unlock(&mutex);
+        sem_post(&full);
+    }
+    return NULL;
+}
+
+void *consumer(void *cno)
+{
+    for(int i = 0; i < MaxItems; i++) {
+        sleep(3);
+        sem_wait(&full);
+        pthread_mutex_lock(&mutex);
+        int item = buffer[out];
+        if (DEBUG) {
+          printf("Consumer %d: Remove Item %d from %d\n",
+                 *((int *)cno),item, out);
+        }
+        out = (out+1)%BufferSize;
+        pthread_mutex_unlock(&mutex);
+        sem_post(&empty);
+    }
+    return NULL;
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc < 4) {
+      printf("Usage: %s <NUM_PRODUCERS> <NUM_CONSUMERS> <DEBUG>\n", argv[0]);
+      return 1;
+    }
+
+    int NUM_PRODUCERS = atoi(argv[1]);
+    int NUM_CONSUMERS = atoi(argv[2]);
+    DEBUG = atoi(argv[3]);
+
+    pthread_t pro[NUM_PRODUCERS],con[NUM_CONSUMERS];
+
+    pthread_mutex_init(&mutex, NULL);
+    sem_init(&empty,0,BufferSize);
+    sem_init(&full,0,0);
+
+    int a[NUM_PRODUCERS > NUM_CONSUMERS ? NUM_PRODUCERS : NUM_CONSUMERS];
+
+    for(int i = 0; i < NUM_PRODUCERS; i++) {
+        a[i] = i+1;
+        pthread_create(&pro[i], NULL, producer, (void *)&a[i]);
+    }
+    for(int i = 0; i < NUM_CONSUMERS; i++) {
+        a[i] = i+1;
+        pthread_create(&con[i], NULL, consumer, (void *)&a[i]);
+    }
+
+    for(int i = 0; i < NUM_PRODUCERS; i++) {
+        pthread_join(pro[i], NULL);
+    }
+    for(int i = 0; i < NUM_CONSUMERS; i++) {
+        pthread_join(con[i], NULL);
+    }
+
+    return 0;
+}

--- a/dmtcp/src/lib/dmtcp-callback.c
+++ b/dmtcp/src/lib/dmtcp-callback.c
@@ -18,9 +18,14 @@
 int dmtcp_mcmini_is_loaded() { return 1; }
 
 pthread_t ckpt_pthread_descriptor;
+volatile atomic_bool libmcmini_has_recorded_checkpoint_thread;
 static sem_t template_thread_sem;
 static pthread_cond_t template_thread_cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t template_thread_mut = PTHREAD_MUTEX_INITIALIZER;
+
+bool is_checkpoint_thread(void) {
+  return pthread_equal(pthread_self(), ckpt_pthread_descriptor);
+}
 
 void thread_handle_after_dmtcp_restart(void) {
   // IMPORTANT: There's a potential race between
@@ -79,7 +84,7 @@ void mc_template_thread_loop_forever() {
     log_debug("Waiting for child process");
 
     // This `wait()` call is important here, as it ensures that there
-    // exists only a single branch alive at any given time. If multiple 
+    // exists only a single branch alive at any given time. If multiple
     // branches were alive at once, they would contend for the shared
     // memory and cause data races. By transitivity, the McMini process
     // also waits until the previous branch has completed its execution
@@ -104,7 +109,6 @@ void mc_template_thread_loop_forever() {
     tpt->cpid = cpid;
     libpthread_sem_post((sem_t *)&tpt->mcmini_process_sem);
 
-    // Recall that state transfers occur inside th
     if (!has_transferred_state) {
       has_transferred_state = true;
       unsetenv("MCMINI_NEEDS_STATE");
@@ -347,6 +351,7 @@ static void presuspend_eventHook(DmtcpEvent_t event, DmtcpEventData_t *data) {
         set_current_mode(DMTCP_RESTART_INTO_BRANCH);
         log_debug("`MCMINI_TEMPLATE_LOOP` was not set at restart-time\n");
       }
+
       // During record mode, the shared memory
       // used by the `mcmini` process to control
       // the userspace threads in this process

--- a/dmtcp/src/lib/dmtcp-callback.c
+++ b/dmtcp/src/lib/dmtcp-callback.c
@@ -41,23 +41,17 @@ void thread_handle_after_dmtcp_restart(void) {
       // This is accomplished by using the current "mode" of libmcmini:
       // as long as we're not in the `TARGET_BRANCH_AFTER_RESTART` case, we
       // simply ignore any wakeups
-      printf("[%u:%u:%p] Before broadcast\n", (uint32_t)getpid(),
-      (uint32_t)gettid(), (void*)pthread_self());
       libpthread_mutex_lock(&template_thread_mut);
       while (get_current_mode() != TARGET_BRANCH_AFTER_RESTART) {
-        printf("[%u:%u:%p] INSID broadcast\n", (uint32_t)getpid(),
-          (uint32_t)gettid(), (void*)pthread_self());
         pthread_cond_wait(&template_thread_cond, &template_thread_mut);
       }
       libpthread_mutex_unlock(&template_thread_mut);
-      printf("[%u:%u:%p] After broadcast\n", (uint32_t)getpid(),
-      (uint32_t)gettid(), (void*)pthread_self());
       break;
     }
     case DMTCP_RESTART_INTO_BRANCH: {
       // In the case of calling `dmtcp_restart` fpr each branch, we
       // are expected to immediately talk to the model checker.
-      printf("DMTCP_RESTART_INTO_BRANCH after restart!\n");
+      log_debug("Restarting into branch (DMTCP_RESTART_INTO_BRANCH)\n");
       break;
     }
     default: {
@@ -78,13 +72,21 @@ void thread_handle_after_dmtcp_restart(void) {
 
 void mc_template_thread_loop_forever() {
   bool has_transferred_state = false;
+
   volatile struct mcmini_shm_file *shm_file = global_shm_start;
   volatile struct template_process_t *tpt = &shm_file->tpt;
   while (1) {
     log_debug("Waiting for child process");
+
+    // This `wait()` call is important here, as it ensures that there
+    // exists only a single branch alive at any given time. If multiple 
+    // branches were alive at once, they would contend for the shared
+    // memory and cause data races. By transitivity, the McMini process
+    // also waits until the previous branch has completed its execution
+    // by waiting on the template
     wait(NULL);
     log_debug("Waiting for `mcmini` to signal a fork");
-    sem_wait((sem_t *)&tpt->libmcmini_sem);
+    libpthread_sem_wait((sem_t *)&tpt->libmcmini_sem);
     log_debug("`mcmini` signaled a fork!");
     const pid_t ppid_before_fork = getpid();
     const pid_t cpid = multithreaded_fork();
@@ -100,8 +102,9 @@ void mc_template_thread_loop_forever() {
     // `libmcmini.so` acting as a template process.
     printf("The template process created child with pid %d\n", cpid);
     tpt->cpid = cpid;
-    sem_post((sem_t *)&tpt->mcmini_process_sem);
+    libpthread_sem_post((sem_t *)&tpt->mcmini_process_sem);
 
+    // Recall that state transfers occur inside th
     if (!has_transferred_state) {
       has_transferred_state = true;
       unsetenv("MCMINI_NEEDS_STATE");
@@ -169,7 +172,7 @@ static void *template_thread(void *unused) {
   libpthread_sem_post((sem_t *)&tpt->mcmini_process_sem);
 
   if (get_current_mode() == DMTCP_RESTART_INTO_TEMPLATE) {
-    printf("DMTCP_RESTART_INTO_TEMPLATE\n");
+    log_debug("Restarting into template (DMTCP_RESTART_INTO_TEMPLATE)\n");
     mc_template_thread_loop_forever();
 
     // Reaching this point means that we're in the branch: the
@@ -218,6 +221,10 @@ static void *template_thread(void *unused) {
         printf("Writing thread entry %p (id %d, status: %d)\n",
                (void *)entry->vo.thrd_state.pthread_desc,
                entry->vo.thrd_state.id, entry->vo.thrd_state.status);
+      } else if (entry->vo.type == SEMAPHORE) {
+        printf("Writing semaphore entry %p (count %d, status: %d)\n",
+               (void *)entry->vo.location,
+               entry->vo.sem_state.count, entry->vo.sem_state.status);
       } else {
         libc_abort();
       }

--- a/dmtcp/src/lib/interception.c
+++ b/dmtcp/src/lib/interception.c
@@ -77,6 +77,7 @@ void mc_load_intercepted_pthread_functions(void) {
   sem_timedwait_ptr = dlsym(libpthread_handle, "sem_timedwait");
   sem_post_ptr = dlsym(libpthread_handle, "sem_post");
   sem_init_ptr = dlsym(libpthread_handle, "sem_init");
+  sem_destroy_ptr = dlsym(libpthread_handle, "sem_destroy");
   pthread_cond_init_ptr = dlsym(libpthread_handle, "pthread_cond_init");
   pthread_cond_wait_ptr = dlsym(libpthread_handle, "pthread_cond_wait");
   pthread_cond_signal_ptr = dlsym(libpthread_handle, "pthread_cond_signal");
@@ -210,9 +211,14 @@ pid_t libc_fork(void) {
 int sem_init(sem_t*sem, int p, unsigned count) {
   return mc_sem_init(sem, p, count);
 }
+int sem_destroy(sem_t *sem) { return mc_sem_destroy(sem); }
 int libpthread_sem_init(sem_t *sem, int pshared, int value) {
   libmcmini_init();
   return (*sem_init_ptr)(sem, pshared, value);
+}
+int libpthread_sem_destroy(sem_t *sem) {
+  libmcmini_init();
+  return (*sem_destroy_ptr)(sem);
 }
 int sem_post(sem_t* sem) {
   return mc_sem_post(sem);

--- a/dmtcp/src/lib/interception.c
+++ b/dmtcp/src/lib/interception.c
@@ -72,6 +72,7 @@ void mc_load_intercepted_pthread_functions(void) {
   pthread_mutex_timedlock_ptr = dlsym(libpthread_handle, "pthread_mutex_timedlock");
   pthread_mutex_unlock_ptr = dlsym(libpthread_handle, "pthread_mutex_unlock");
   pthread_mutex_destroy_ptr = dlsym(libpthread_handle, "pthread_mutex_destroy");
+  sem_timedwait_ptr = dlsym(libpthread_handle, "sem_timedwait");
   sem_wait_ptr = dlsym(libpthread_handle, "sem_wait");
   sem_timedwait_ptr = dlsym(libpthread_handle, "sem_timedwait");
   sem_post_ptr = dlsym(libpthread_handle, "sem_post");
@@ -206,13 +207,22 @@ pid_t libc_fork(void) {
   return (*fork_ptr)();
 }
 
+int sem_init(sem_t*sem, int p, unsigned count) {
+  return mc_sem_init(sem, p, count);
+}
 int libpthread_sem_init(sem_t *sem, int pshared, int value) {
   libmcmini_init();
   return (*sem_init_ptr)(sem, pshared, value);
 }
+int sem_post(sem_t* sem) {
+  return mc_sem_post(sem);
+}
 int libpthread_sem_post(sem_t *sem) {
   libmcmini_init();
   return (*sem_post_ptr)(sem);
+}
+int sem_wait(sem_t *sem) {
+  return mc_sem_wait(sem);
 }
 int libpthread_sem_wait(sem_t *sem) {
   libmcmini_init();

--- a/dmtcp/src/lib/record.c
+++ b/dmtcp/src/lib/record.c
@@ -2,6 +2,7 @@
 #include "mcmini/spy/checkpointing/rec_list.h"
 #include "mcmini/spy/checkpointing/objects.h"
 #include "mcmini/spy/checkpointing/transitions.h"
+#include "mcmini/spy/intercept/interception.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -77,7 +78,7 @@ rec_list *add_rec_entry_record_mode(const visible_object *vo) {
   return new_node;
 }
 
-void notify_template_thread() { sem_post(&dmtcp_restart_sem); }
+void notify_template_thread() { libpthread_sem_post(&dmtcp_restart_sem); }
 
 bool is_in_restart_mode(void) {
   enum libmcmini_mode mode = get_current_mode();

--- a/dmtcp/src/lib/record.c
+++ b/dmtcp/src/lib/record.c
@@ -85,7 +85,19 @@ bool is_in_restart_mode(void) {
   return mode == DMTCP_RESTART_INTO_BRANCH ||
          mode == DMTCP_RESTART_INTO_TEMPLATE;
 }
-enum libmcmini_mode get_current_mode() { return atomic_load(&libmcmini_mode); }
+
+enum libmcmini_mode get_current_mode() {
+  // INVARIANT (imposed by the code in `mc_pthread_create()`):
+  // The checkpoint thread is guaranteed to reach the line
+  // "is_checkpoint_thread()", because the only time in which the atomic is
+  // stored is BEFORE the checkpoint thread has executed DMTCP code.
+  if (atomic_load(&libmcmini_has_recorded_checkpoint_thread)) {
+    if (is_checkpoint_thread()) {
+      return CHECKPOINT_THREAD;
+    }
+  }
+  return atomic_load(&libmcmini_mode);
+}
 void set_current_mode(enum libmcmini_mode new_mode) {
   atomic_store(&libmcmini_mode, new_mode);
 }

--- a/dmtcp/src/lib/sem-wrappers.c
+++ b/dmtcp/src/lib/sem-wrappers.c
@@ -1,0 +1,188 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "mcmini/mcmini.h"
+
+int mc_sem_init(sem_t *sem, int p, unsigned count) {
+  // TODO: Does not handle interprocess semaphores
+  assert(p == 0);
+
+  switch (get_current_mode()) {
+    case PRE_DMTCP_INIT:
+    case PRE_CHECKPOINT_THREAD: {
+      return libpthread_sem_init(sem, p, count);
+    }
+    case RECORD:
+    case PRE_CHECKPOINT: {
+      libpthread_mutex_lock(&rec_list_lock);
+      rec_list *sem_record = find_object_record_mode(sem);
+      if (sem_record == NULL) {
+        visible_object vo = {.type = SEMAPHORE,
+                             .location = sem,
+                             .sem_state.status = SEM_UNINITIALIZED};
+        sem_record = add_rec_entry_record_mode(&vo);
+      }
+      libpthread_mutex_unlock(&rec_list_lock);
+
+      int rc = libpthread_sem_init(sem, p, count);
+      if (rc == 0) {
+        libpthread_mutex_lock(&rec_list_lock);
+        rec_list *sem_record = find_object_record_mode(sem);
+        assert(sem_record != NULL);
+        visible_object vo = {.type = SEMAPHORE,
+                             .location = sem,
+                             .sem_state.status = SEM_INITIALIZED,
+                             .sem_state.count = count};
+        sem_record->vo = vo;
+        libpthread_mutex_unlock(&rec_list_lock);
+      }
+      return rc;
+    }
+    case TARGET_BRANCH:
+    case TARGET_BRANCH_AFTER_RESTART:
+    case DMTCP_RESTART_INTO_BRANCH:
+    case DMTCP_RESTART_INTO_TEMPLATE: {
+      volatile runner_mailbox *mb = thread_get_mailbox();
+      mb->type = SEM_INIT_TYPE;
+      memcpy_v(mb->cnts, &sem, sizeof(sem));
+      memcpy_v(mb->cnts + sizeof(sem), &count, sizeof(count));
+      is_in_restart_mode() ? thread_handle_after_dmtcp_restart() : thread_wake_scheduler_and_wait();
+      return libpthread_sem_init(sem, p, count);
+    }
+    default: {
+      // Wrapper functions should not be executing
+      // inside the template! If we reach this point, it
+      // means that this is a template process. This
+      // method must have been directly called
+      // erroneously.
+      libc_abort();
+    }
+  }
+}
+
+int
+mc_sem_post(sem_t *sem) {
+switch (get_current_mode()) {
+    case PRE_DMTCP_INIT:
+    case PRE_CHECKPOINT_THREAD: {
+      return libpthread_sem_post(sem);
+    }
+    case RECORD:
+    case PRE_CHECKPOINT: {
+      libpthread_mutex_lock(&rec_list_lock);
+      rec_list *sem_record = find_object_record_mode(sem);
+      if (sem_record == NULL) {
+        // FIXME: We only change into record mode once the
+        // checkpoint thread has
+        int count = 0;
+        sem_getvalue(sem, &count);
+        visible_object vo = {.type = SEMAPHORE,
+                             .location = sem,
+                             .sem_state.status = SEM_INITIALIZED,
+                             .sem_state.count = count};
+        sem_record = add_rec_entry_record_mode(&vo);
+      }
+      libpthread_mutex_unlock(&rec_list_lock);
+      int rc = libpthread_sem_post(sem);
+      if (rc == 0) {  // Post succeeded
+        libpthread_mutex_lock(&rec_list_lock);
+        sem_record->vo.sem_state.count++;
+        libpthread_mutex_unlock(&rec_list_lock);
+      }
+      return rc;
+    }
+    case TARGET_BRANCH:
+    case TARGET_BRANCH_AFTER_RESTART:
+    case DMTCP_RESTART_INTO_BRANCH:
+    case DMTCP_RESTART_INTO_TEMPLATE: {
+      volatile runner_mailbox *mb = thread_get_mailbox();
+      mb->type = SEM_POST_TYPE;
+      memcpy_v(mb->cnts, &sem, sizeof(sem));
+      is_in_restart_mode() ? thread_handle_after_dmtcp_restart() : thread_wake_scheduler_and_wait();
+      return libpthread_sem_post(sem);
+    }
+    default: {
+      // Wrapper functions should not be executing
+      // inside the template! If we reach this point, it
+      // means that this is a template process. This
+      // method must have been directly called
+      // erroneously.
+      libc_abort();
+    }
+  }
+}
+
+int mc_sem_wait(sem_t *sem) {
+  switch (get_current_mode()) {
+    case PRE_DMTCP_INIT:
+    case PRE_CHECKPOINT_THREAD: {
+      return libpthread_sem_wait(sem);
+    }
+    case RECORD:
+    case PRE_CHECKPOINT: {
+      libpthread_mutex_lock(&rec_list_lock);
+      rec_list *sem_record = find_object_record_mode(sem);
+      if (sem_record == NULL) {
+        int count = 0;
+        sem_getvalue(sem, &count);
+        visible_object vo = {.type = SEMAPHORE,
+                             .location = sem,
+                             .sem_state.status = SEM_INITIALIZED,
+                             .sem_state.count = count};
+        sem_record = add_rec_entry_record_mode(&vo);
+      }
+      libpthread_mutex_unlock(&rec_list_lock);
+
+      struct timespec ts;
+      while (1) {
+        // Wait one second...
+        clock_gettime(CLOCK_REALTIME, &ts); ts.tv_sec++;
+        int rc = libpthread_sem_timedwait(sem, &ts);
+        if (rc == 0) {  // Wait succeeded
+          libpthread_mutex_lock(&rec_list_lock);
+          sem_record->vo.sem_state.count--;
+          libpthread_mutex_unlock(&rec_list_lock);
+          return rc;
+        } else if (rc == ETIMEDOUT) {  // If the lock failed.
+          // Here, the user-space thread did not manage to wait on the
+          // the lock. However, we do NOT want threads to block during
+          // the recording phase to ensure that each user-space thread
+          // can be put back under the control of the model checker.
+          //
+          // For those threads which have not managed to enter,
+          // we want to ensure that they can eventually escape from this loop.
+          // After the DMTCP_EVENT_RESTART event, other threads must notice that
+          // the record phase has ended or else they could loop forever.
+          if (is_in_restart_mode()) {
+            break;
+          }
+        } else if (rc != 0 && rc != ETIMEDOUT) {
+          // A "true" error: something went wrong with locking
+          // and we pass this on to the end user
+          return rc;
+        }
+      }
+      // Explicit fallthrough
+    }
+    case TARGET_BRANCH:
+    case TARGET_BRANCH_AFTER_RESTART:
+    case DMTCP_RESTART_INTO_BRANCH:
+    case DMTCP_RESTART_INTO_TEMPLATE: {
+      volatile runner_mailbox *mb = thread_get_mailbox();
+      mb->type = SEM_WAIT_TYPE;
+      memcpy_v(mb->cnts, &sem, sizeof(sem));
+      is_in_restart_mode() ? thread_handle_after_dmtcp_restart() : thread_wake_scheduler_and_wait();
+      return libpthread_sem_post(sem);
+    }
+    default: {
+      // Wrapper functions should not be executing
+      // inside the template! If we reach this point, it
+      // means that this is a template process. This
+      // method must have been directly called
+      // erroneously.
+      libc_abort();
+    }
+  }
+}

--- a/dmtcp/src/lib/template/loop.c
+++ b/dmtcp/src/lib/template/loop.c
@@ -6,7 +6,9 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <dmtcp.h>
 
+#include "mcmini/common/exit.h"
 #include "mcmini/common/shm_config.h"
 #include "mcmini/defines.h"
 #include "mcmini/lib/entry.h"
@@ -30,9 +32,7 @@ void mc_prepare_new_child_process(pid_t ppid_before_fork) {
   // current parent process id differs from the process id of the parent which
   // fork()-ed this process. If they don't match, we know that the parent exited
   // before prctl()
-
-  // TEMPORARY FIXME !!!!
-  // if (getppid() != ppid_before_fork) mc_exit(EXIT_FAILURE);
+  if (dmtcp_real_to_virtual_pid(getppid()) != ppid_before_fork) mc_exit(EXIT_FAILURE);
 
   // This is important to handle the case when the
   // main thread exits `in main()`; in that case, we
@@ -50,31 +50,4 @@ void mc_prepare_new_child_process(pid_t ppid_before_fork) {
   // action.sa_handler = SegvfaultHandler;
   // sigemptyset(&action.sa_mask);
   // sigaction(SIGSEGV, &action, NULL);
-}
-
-void mc_template_process_loop_forever(pid_t (*make_new_process)(void)) {
-  volatile struct mcmini_shm_file *shm_file = global_shm_start;
-  volatile struct template_process_t *tpt = &shm_file->tpt;
-  while (1) {
-    log_debug("Waiting for child process");
-    wait(NULL);
-    log_debug("Waiting for `mcmini` to signal a fork");
-    libpthread_sem_wait((sem_t *)&tpt->libmcmini_sem);
-    log_debug("`mcmini` signaled a fork!");
-    const pid_t ppid_before_fork = getpid();
-    const pid_t cpid = make_new_process();
-    if (cpid == -1) {
-      // `fork()` failed
-      tpt->err = errno;
-      tpt->cpid = TEMPLATE_FORK_FAILED;
-    } else if (cpid == 0) {
-      // Child case: Simply return and escape into the child process.
-      mc_prepare_new_child_process(ppid_before_fork);
-      return;
-    }
-    // `libmcmini.so` acting as a template process.
-    printf("The template process created child with pid %d\n", cpid);
-    tpt->cpid = cpid;
-    libpthread_sem_post((sem_t *)&tpt->mcmini_process_sem);
-  }
 }

--- a/dmtcp/src/lib/template/loop.c
+++ b/dmtcp/src/lib/template/loop.c
@@ -15,7 +15,6 @@
 #include "mcmini/spy/checkpointing/record.h"
 #include "mcmini/spy/intercept/interception.h"
 
-
 void mc_prepare_new_child_process(pid_t ppid_before_fork) {
   // IMPORTANT: If the THREAD in the template process ever exits, this will
   // prove problematic as it is when the THREAD which called `fork()` exits that
@@ -60,7 +59,7 @@ void mc_template_process_loop_forever(pid_t (*make_new_process)(void)) {
     log_debug("Waiting for child process");
     wait(NULL);
     log_debug("Waiting for `mcmini` to signal a fork");
-    sem_wait((sem_t *)&tpt->libmcmini_sem);
+    libpthread_sem_wait((sem_t *)&tpt->libmcmini_sem);
     log_debug("`mcmini` signaled a fork!");
     const pid_t ppid_before_fork = getpid();
     const pid_t cpid = make_new_process();
@@ -76,6 +75,6 @@ void mc_template_process_loop_forever(pid_t (*make_new_process)(void)) {
     // `libmcmini.so` acting as a template process.
     printf("The template process created child with pid %d\n", cpid);
     tpt->cpid = cpid;
-    sem_post((sem_t *)&tpt->mcmini_process_sem);
+    libpthread_sem_post((sem_t *)&tpt->mcmini_process_sem);
   }
 }

--- a/dmtcp/src/lib/wrappers.c
+++ b/dmtcp/src/lib/wrappers.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include <assert.h>
+#include <stdio.h>
 #include <dmtcp.h>
 #include <errno.h>
 #include <pthread.h>
@@ -68,8 +69,6 @@ void thread_block_indefinitely(void) {
     pause();
   }
 }
-
-void thread_handle_after_dmtcp_restart(void);
 
 int mc_pthread_mutex_init(pthread_mutex_t *mutex,
                           const pthread_mutexattr_t *attr) {
@@ -444,6 +443,7 @@ void record_main_thread(void) {
   // Since the checkpoint thread is about to be created, it is safe to begin
   // recording.
   set_current_mode(RECORD);
+  printf("RECORDMODESET\n");
 }
 
 int mc_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
@@ -463,6 +463,7 @@ int mc_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
       assert(0);
     }
     case PRE_CHECKPOINT_THREAD: {
+      printf("PRE_CHECKPOINT_THREAD\n");
       pthread_once(&main_thread_once, &record_main_thread);
       int rc = libdmtcp_pthread_create(thread, attr, routine, arg);
       ckpt_pthread_descriptor = *thread;

--- a/dmtcp/src/lib/wrappers.c
+++ b/dmtcp/src/lib/wrappers.c
@@ -81,7 +81,8 @@ int mc_pthread_mutex_init(pthread_mutex_t *mutex,
 
   switch (get_current_mode()) {
     case PRE_DMTCP_INIT:
-    case PRE_CHECKPOINT_THREAD: {
+    case PRE_CHECKPOINT_THREAD:
+    case CHECKPOINT_THREAD: {
       return libpthread_mutex_init(mutex, attr);
     }
     case RECORD:
@@ -159,7 +160,8 @@ int mc_pthread_mutex_lock(pthread_mutex_t *mutex) {
   // tracking.
   switch (get_current_mode()) {
     case PRE_DMTCP_INIT:
-    case PRE_CHECKPOINT_THREAD: {
+    case PRE_CHECKPOINT_THREAD:
+    case CHECKPOINT_THREAD: {
       return libpthread_mutex_lock(mutex);
     }
     case RECORD:
@@ -236,7 +238,8 @@ int mc_pthread_mutex_lock(pthread_mutex_t *mutex) {
 int mc_pthread_mutex_unlock(pthread_mutex_t *mutex) {
   switch (get_current_mode()) {
     case PRE_DMTCP_INIT:
-    case PRE_CHECKPOINT_THREAD: {
+    case PRE_CHECKPOINT_THREAD:
+    case CHECKPOINT_THREAD: {
       return libpthread_mutex_unlock(mutex);
     }
     case RECORD:
@@ -340,10 +343,11 @@ void *mc_thread_routine_wrapper(void *arg) {
   struct mc_thread_routine_arg *unwrapped_arg = arg;
   switch (get_current_mode()) {
     case PRE_DMTCP_INIT:
-    case PRE_CHECKPOINT_THREAD: {
+    case PRE_CHECKPOINT_THREAD:
+    case CHECKPOINT_THREAD: {
       fprintf(stderr,
       "In `PRE_DMTCP_INIT` mode, `mc_pthread_create` always directly calls DMTCP."
-      "Reaching this point means that the McMini wrapper would be an error.\n");
+      "Reaching this point would be an error.\n");
       libc_abort();
     }
     case RECORD:
@@ -543,7 +547,8 @@ int mc_pthread_join(pthread_t t, void **rv) {
       // NOTE: Explicit fallthrough intended
       assert(0);
     }
-    case PRE_CHECKPOINT_THREAD: {
+    case PRE_CHECKPOINT_THREAD:
+    case CHECKPOINT_THREAD: {
       return libdmtcp_pthread_join(t, rv);
     }
     case RECORD:

--- a/dmtcp/src/lib/wrappers.c
+++ b/dmtcp/src/lib/wrappers.c
@@ -1,9 +1,9 @@
 #define _GNU_SOURCE
 #include <assert.h>
-#include <stdio.h>
 #include <dmtcp.h>
 #include <errno.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,8 +11,8 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "mcmini/mcmini.h"
 #include "mcmini/common/exit.h"
+#include "mcmini/mcmini.h"
 
 MCMINI_THREAD_LOCAL runner_id_t tid_self = RID_INVALID;
 
@@ -27,6 +27,9 @@ runner_id_t mc_register_this_thread(void) {
 }
 
 volatile runner_mailbox *thread_get_mailbox() {
+  assert(!is_checkpoint_thread());
+  assert(tid_self != RID_INVALID);
+  assert(tid_self != RID_CHECKPOINT_THREAD);
   return &((volatile struct mcmini_shm_file *)(global_shm_start))
               ->mailboxes[tid_self];
 }
@@ -439,15 +442,29 @@ void record_main_thread(void) {
                        .thrd_state.status = ALIVE};
   thread_record = add_rec_entry_record_mode(&vo);
   libpthread_mutex_unlock(&rec_list_lock);
+}
 
-  // Recording the presence of the main thread means that the main
+void record_checkpoint_thread(void) {
+  tid_self = RID_CHECKPOINT_THREAD;
+  ckpt_pthread_descriptor = pthread_self();
+  atomic_store(&libmcmini_has_recorded_checkpoint_thread, true);
+
+  // Recording the presence of the checkpoint thread means that the main
   // thread has made its first call to `pthread_create`. The assumption
   // is that DMTCP (executing in the main thread before the `main` routine)
   // makes the first call to `pthread_create` to create the checkpoint thread.
   // Since the checkpoint thread is about to be created, it is safe to begin
   // recording.
   set_current_mode(RECORD);
-  printf("RECORDMODESET\n");
+}
+
+void *dmtcp_create_checkpoint_thread_wrapper(void *arg) {
+  record_checkpoint_thread();
+  struct mc_thread_routine_arg *unwrapped_arg = arg;
+  libpthread_sem_post(&unwrapped_arg->mc_pthread_create_binary_sem);
+  void *rv = unwrapped_arg->routine(unwrapped_arg->arg);
+  free(arg);
+  return rv;
 }
 
 int mc_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
@@ -462,16 +479,45 @@ int mc_pthread_create(pthread_t *thread, const pthread_attr_t *attr,
     case PRE_DMTCP_INIT: {
       // This case implies that DMTCP attempted to create
       // a thread BEFORE the `DMTCP_EVENT_INIT` was delivered
-      // to `libmcmini`'s callback.
+      // to `libmcmini`'s callback. This
       // NOTE: Explicit fallthrough intended
       assert(0);
     }
     case PRE_CHECKPOINT_THREAD: {
-      printf("PRE_CHECKPOINT_THREAD\n");
       pthread_once(&main_thread_once, &record_main_thread);
-      int rc = libdmtcp_pthread_create(thread, attr, routine, arg);
-      ckpt_pthread_descriptor = *thread;
+
+      // We must be able to at runtime determine which thread is the checkpoint
+      // thread. Here we record the `pthread_t` struct assigned to the
+      // checkpoint thread and later compare it with the value returned by
+      // `pthread_create()`.
+      //
+      // NOTE: The semaphore is necessary here as the child thread in this
+      // instance will be the checkpoint thread and will hence call into DMTCP.
+      // Since the goal of detecting if the caller is the checkpoint thread
+      // inside of wrappers is to prevent the checkpoint thread from interacting
+      // with McMini wrappers, and since we write the checkpoint thread's
+      // `pthread_t` into a globally accessible location, we must synchronize
+      // with the checkpoint thread.
+      struct mc_thread_routine_arg *wrapped_arg =
+          malloc(sizeof(struct mc_thread_routine_arg));
+      wrapped_arg->arg = arg;
+      wrapped_arg->routine = routine;
+      libpthread_sem_init(&wrapped_arg->mc_pthread_create_binary_sem, 0, 0);
+      int rc = libdmtcp_pthread_create(
+          thread, attr, &dmtcp_create_checkpoint_thread_wrapper, wrapped_arg);
+      libpthread_sem_wait(&wrapped_arg->mc_pthread_create_binary_sem);
       return rc;
+    }
+    case CHECKPOINT_THREAD: {
+      log_warn(
+          "The checkpoint thread is creating another thread. Calls from this "
+          "thread should probably be ignored by the McMini library, as "
+          "creating a thread indicates the checkpoint thread is doing "
+          "background work. The DMTCP library and McMini must not interefere. "
+          "However, the current implementation "
+          "only prevents calls by the checkpoint thread from entering wrapper "
+          "functions.");
+      return libdmtcp_pthread_create(thread, attr, routine, arg);
     }
     case RECORD:
     case PRE_CHECKPOINT:

--- a/dmtcp/src/mcmini/mcmini.cpp
+++ b/dmtcp/src/mcmini/mcmini.cpp
@@ -449,6 +449,11 @@ int main_cpp(int argc, const char** argv) {
       exit(1);
     }
     mcmini_config.target_executable = std::string(cur_arg[0]);
+
+    // Gather the rest of the args
+    int c = 0;
+    while (cur_arg[++c])
+      mcmini_config.target_executable_args.push_back(cur_arg[c]);
   }
 
   install_process_wide_signal_handlers();

--- a/dmtcp/src/mcmini/mcmini.cpp
+++ b/dmtcp/src/mcmini/mcmini.cpp
@@ -5,10 +5,6 @@
 #include "mcmini/model/objects/mutex.hpp"
 #include "mcmini/model/objects/semaphore.hpp"
 #include "mcmini/model/objects/thread.hpp"
-#include "mcmini/model/transition_registry.hpp"
-#include "mcmini/model/transitions/mutex/callbacks.hpp"
-#include "mcmini/model/transitions/semaphore/callbacks.hpp"
-#include "mcmini/model/transitions/thread/callbacks.hpp"
 #include "mcmini/model_checking/algorithm.hpp"
 #include "mcmini/model_checking/algorithms/classic_dpor.hpp"
 #include "mcmini/real_world/fifo.hpp"
@@ -16,8 +12,6 @@
 #include "mcmini/real_world/process/multithreaded_fork_process_source.hpp"
 #include "mcmini/real_world/process/resources.hpp"
 #include "mcmini/signal.hpp"
-#include "mcmini/spy/checkpointing/objects.h"
-#include "mcmini/spy/checkpointing/transitions.h"
 
 #define _XOPEN_SOURCE_EXTENDED 1
 
@@ -122,61 +116,17 @@ void found_deadlock(const coordinator& c) {
 
 void do_model_checking(const config& config) {
   algorithm::callbacks c;
-  transition_registry tr;
-  detached_state state_of_program_at_main;
-  pending_transitions initial_first_steps;
-  classic_dpor::dependency_relation_type dr;
-  classic_dpor::coenabled_relation_type cr;
-
-  tr.register_transition(MUTEX_INIT_TYPE, &mutex_init_callback);
-  tr.register_transition(MUTEX_LOCK_TYPE, &mutex_lock_callback);
-  tr.register_transition(MUTEX_UNLOCK_TYPE, &mutex_unlock_callback);
-  tr.register_transition(THREAD_CREATE_TYPE, &thread_create_callback);
-  tr.register_transition(THREAD_EXIT_TYPE, &thread_exit_callback);
-  tr.register_transition(THREAD_JOIN_TYPE, &thread_join_callback);
-  tr.register_transition(SEM_INIT_TYPE, &sem_init_callback);
-  tr.register_transition(SEM_DESTROY_TYPE, &sem_destroy_callback);
-  tr.register_transition(SEM_POST_TYPE, &sem_post_callback);
-  tr.register_transition(SEM_WAIT_TYPE, &sem_wait_callback);
-
-  const state::runner_id_t main_thread_id = state_of_program_at_main.add_runner(
-      new objects::thread(objects::thread::state::running));
-  initial_first_steps.set_transition(
-      new transitions::thread_start(main_thread_id));
-  program model_for_program_starting_at_main(state_of_program_at_main,
-                                             std::move(initial_first_steps));
-
   target target_program(config.target_executable,
                         config.target_executable_args);
-  coordinator coordinator(std::move(model_for_program_starting_at_main),
-                          std::move(tr),
+  coordinator coordinator(program::starting_from_main(),
+                          transition_registry::default_registry(),
                           make_unique<fork_process_source>(target_program));
-
   std::cerr << "\n\n**************** INTIAL STATE *********************\n\n";
   coordinator.get_current_program_model().dump_state(std::cerr);
   std::cerr << "\n\n**************** INTIAL STATE *********************\n\n";
   std::cerr.flush();
 
-  dr.register_dd_entry<const transitions::thread_create>(
-      &transitions::thread_create::depends);
-  dr.register_dd_entry<const transitions::thread_join>(
-      &transitions::thread_join::depends);
-  dr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_init>(
-      &transitions::mutex_lock::depends);
-  dr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_lock>(
-      &transitions::mutex_lock::depends);
-  cr.register_dd_entry<const transitions::thread_create>(
-      &transitions::thread_create::coenabled_with);
-  cr.register_dd_entry<const transitions::thread_join>(
-      &transitions::thread_join::coenabled_with);
-  cr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_unlock>(
-      &transitions::mutex_lock::coenabled_with);
-
-  model_checking::classic_dpor classic_dpor_checker(std::move(dr),
-                                                    std::move(cr));
+  model_checking::classic_dpor classic_dpor_checker;
   c.trace_completed = &finished_trace_classic_dpor;
   c.deadlock = &found_deadlock;
   c.undefined_behavior = &found_undefined_behavior;
@@ -203,16 +153,9 @@ void do_model_checking_from_dmtcp_ckpt_file(const config& config) {
   // process is ready for execution; otherwise, the state restoration will not
   // work as expected.
   algorithm::callbacks c;
-  transition_registry tr;
-  tr.register_transition(MUTEX_INIT_TYPE, &mutex_init_callback);
-  tr.register_transition(MUTEX_LOCK_TYPE, &mutex_lock_callback);
-  tr.register_transition(MUTEX_UNLOCK_TYPE, &mutex_unlock_callback);
-  tr.register_transition(THREAD_CREATE_TYPE, &thread_create_callback);
-  tr.register_transition(THREAD_EXIT_TYPE, &thread_exit_callback);
-  tr.register_transition(THREAD_JOIN_TYPE, &thread_join_callback);
+  transition_registry tr = transition_registry::default_registry();
 
-  coordinator coordinator(model::program(), tr,
-                          std::move(dmtcp_template_handle));
+  coordinator coordinator(program(), tr, std::move(dmtcp_template_handle));
   {
     model_to_system_map recorder(coordinator);
 
@@ -253,6 +196,10 @@ void do_model_checking_from_dmtcp_ckpt_file(const config& config) {
       volatile runner_mailbox* mb = &rw_region->mailboxes[recorded_id];
       transition_registry::transition_discovery_callback callback =
           tr.get_callback_for(mb->type);
+      if (!callback) {
+        throw std::runtime_error("Expected a callback for " +
+                                 std::to_string(mb->type));
+      }
       const size_t num_objects_before =
           coordinator.get_current_program_model().get_state_sequence().count();
       recorder.observe_runner_transition(callback(recorded_id, *mb, recorder));
@@ -279,28 +226,7 @@ void do_model_checking_from_dmtcp_ckpt_file(const config& config) {
   std::cerr << "\n\n**************** INTIAL STATE *********************\n\n";
   std::cerr.flush();
 
-  classic_dpor::dependency_relation_type dr;
-  classic_dpor::coenabled_relation_type cr;
-  dr.register_dd_entry<const transitions::thread_create>(
-      &transitions::thread_create::depends);
-  dr.register_dd_entry<const transitions::thread_join>(
-      &transitions::thread_join::depends);
-  dr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_init>(
-      &transitions::mutex_lock::depends);
-  dr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_lock>(
-      &transitions::mutex_lock::depends);
-  cr.register_dd_entry<const transitions::thread_create>(
-      &transitions::thread_create::coenabled_with);
-  cr.register_dd_entry<const transitions::thread_join>(
-      &transitions::thread_join::coenabled_with);
-  cr.register_dd_entry<const transitions::mutex_lock,
-                       const transitions::mutex_unlock>(
-      &transitions::mutex_lock::coenabled_with);
-  model_checking::classic_dpor classic_dpor_checker(std::move(dr),
-                                                    std::move(cr));
-
+  model_checking::classic_dpor classic_dpor_checker;
   c.trace_completed = &finished_trace_classic_dpor;
   c.undefined_behavior = &found_undefined_behavior;
   c.deadlock = &found_deadlock;

--- a/dmtcp/src/mcmini/model/program.cpp
+++ b/dmtcp/src/mcmini/model/program.cpp
@@ -8,10 +8,12 @@
 #include <unordered_set>
 #include <utility>
 
+#include "mcmini/model/objects/thread.hpp"
 #include "mcmini/model/pending_transitions.hpp"
 #include "mcmini/model/state.hpp"
 #include "mcmini/model/state/detached_state.hpp"
 #include "mcmini/model/transition.hpp"
+#include "mcmini/model/transitions/thread/thread_start.hpp"
 #include "mcmini/model/visible_object_state.hpp"
 
 using namespace model;
@@ -21,6 +23,16 @@ program::program() : program(detached_state(), pending_transitions()) {}
 program::program(const state &initial_state,
                  pending_transitions &&initial_first_steps)
     : state_seq(initial_state), next_steps(std::move(initial_first_steps)) {}
+
+program program::starting_from_main() {
+  detached_state state_of_program_at_main;
+  pending_transitions initial_first_steps;
+  const state::runner_id_t main_thread_id = state_of_program_at_main.add_runner(
+      new objects::thread(objects::thread::state::running));
+  initial_first_steps.set_transition(
+      new transitions::thread_start(main_thread_id));
+  return program(state_of_program_at_main, std::move(initial_first_steps));
+}
 
 std::unordered_set<state::runner_id_t> program::get_enabled_runners() const {
   std::unordered_set<runner_id_t> enabled_runners;

--- a/dmtcp/src/mcmini/model/transition_registry.cpp
+++ b/dmtcp/src/mcmini/model/transition_registry.cpp
@@ -1,0 +1,23 @@
+#include "mcmini/model/transition_registry.hpp"
+
+#include "mcmini/model/transitions/mutex/callbacks.hpp"
+#include "mcmini/model/transitions/semaphore/callbacks.hpp"
+#include "mcmini/model/transitions/thread/callbacks.hpp"
+#include "mcmini/spy/checkpointing/transitions.h"
+
+using namespace model;
+
+transition_registry transition_registry::default_registry() {
+  transition_registry tr;
+  tr.register_transition(MUTEX_INIT_TYPE, &mutex_init_callback);
+  tr.register_transition(MUTEX_LOCK_TYPE, &mutex_lock_callback);
+  tr.register_transition(MUTEX_UNLOCK_TYPE, &mutex_unlock_callback);
+  tr.register_transition(THREAD_CREATE_TYPE, &thread_create_callback);
+  tr.register_transition(THREAD_EXIT_TYPE, &thread_exit_callback);
+  tr.register_transition(THREAD_JOIN_TYPE, &thread_join_callback);
+  tr.register_transition(SEM_INIT_TYPE, &sem_init_callback);
+  tr.register_transition(SEM_DESTROY_TYPE, &sem_destroy_callback);
+  tr.register_transition(SEM_POST_TYPE, &sem_post_callback);
+  tr.register_transition(SEM_WAIT_TYPE, &sem_wait_callback);
+  return tr;
+}

--- a/dmtcp/src/mcmini/model/transitions/semaphore.cpp
+++ b/dmtcp/src/mcmini/model/transitions/semaphore.cpp
@@ -53,3 +53,18 @@ model::transition* sem_wait_callback(runner_id_t p,
   const state::objid_t model_sem = m.get_model_of_object(remote_sem);
   return new transitions::sem_wait(p, model_sem);
 }
+
+model::transition* sem_destroy_callback(runner_id_t p,
+                                        const volatile runner_mailbox& rmb,
+                                        model_to_system_map& m) {
+  sem_t* remote_sem;
+  memcpy_v(&remote_sem, (volatile void*)rmb.cnts, sizeof(sem_t*));
+
+  if (!m.contains(remote_sem))
+    throw undefined_behavior_exception(
+        "Attempting to wait on an uninitialized semaphore");
+
+  // const state::objid_t model_sem = m.get_model_of_object(remote_sem);
+  // return new transitions::sem_destroy(p, model_sem);
+  return nullptr;  // TODO: Implement sem_destroy in the model
+}

--- a/dmtcp/src/mcmini/model/transitions/semaphore.cpp
+++ b/dmtcp/src/mcmini/model/transitions/semaphore.cpp
@@ -1,0 +1,55 @@
+#include "mcmini/mem.h"
+#include "mcmini/model/exception.hpp"
+#include "mcmini/model/transitions/semaphore/callbacks.hpp"
+#include "mcmini/model/transitions/semaphore/sem_init.hpp"
+#include "mcmini/model/transitions/semaphore/sem_post.hpp"
+#include "mcmini/model/transitions/semaphore/sem_wait.hpp"
+
+using namespace model;
+using namespace objects;
+
+model::transition* sem_init_callback(runner_id_t p,
+                                     const volatile runner_mailbox& rmb,
+                                     model_to_system_map& m) {
+  // Fetch the remote object
+  int count;
+  sem_t* remote_sem;
+  memcpy_v(&remote_sem, (volatile void*)rmb.cnts, sizeof(sem_t*));
+  memcpy_v(&count, (volatile void*)(rmb.cnts + sizeof(sem_t*)), sizeof(int));
+
+  // Locate the corresponding model of this object
+  if (!m.contains(remote_sem)) m.observe_object(remote_sem, new semaphore());
+
+  const state::objid_t model_sem = m.get_model_of_object(remote_sem);
+  return new transitions::sem_init(p, model_sem, count);
+}
+
+model::transition* sem_post_callback(runner_id_t p,
+                                     const volatile runner_mailbox& rmb,
+                                     model_to_system_map& m) {
+  sem_t* remote_sem;
+  memcpy_v(&remote_sem, (volatile void*)rmb.cnts, sizeof(sem_t*));
+
+  // TODO: Add code from Gene's PR here to check for initialized semaphores
+  if (!m.contains(remote_sem))
+    throw undefined_behavior_exception(
+        "Attempting to post to an uninitialized semaphore");
+
+  const state::objid_t model_sem = m.get_model_of_object(remote_sem);
+  return new transitions::sem_post(p, model_sem);
+}
+
+model::transition* sem_wait_callback(runner_id_t p,
+                                     const volatile runner_mailbox& rmb,
+                                     model_to_system_map& m) {
+  sem_t* remote_sem;
+  memcpy_v(&remote_sem, (volatile void*)rmb.cnts, sizeof(sem_t*));
+
+  // TODO: Add code from Gene's PR here to check for initialized semaphores
+  if (!m.contains(remote_sem))
+    throw undefined_behavior_exception(
+        "Attempting to wait on an uninitialized semaphore");
+
+  const state::objid_t model_sem = m.get_model_of_object(remote_sem);
+  return new transitions::sem_wait(p, model_sem);
+}

--- a/dmtcp/src/mcmini/real_world/fork_process_source.cpp
+++ b/dmtcp/src/mcmini/real_world/fork_process_source.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<process> fork_process_source::make_new_process() {
         "(errno " +
         std::to_string(tstruct->err) + "): " + strerror(tstruct->err));
   }
-  return extensions::make_unique<local_linux_process>(tstruct->cpid);
+  return extensions::make_unique<local_linux_process>(tstruct->cpid, false);
 }
 
 void fork_process_source::make_new_template_process() {

--- a/dmtcp/src/mcmini/real_world/local_linux_process.cpp
+++ b/dmtcp/src/mcmini/real_world/local_linux_process.cpp
@@ -16,7 +16,8 @@
 
 using namespace real_world;
 
-local_linux_process::local_linux_process(pid_t pid) : pid(pid) {}
+local_linux_process::local_linux_process(pid_t pid, bool should_wait)
+    : pid(pid), should_wait(should_wait) {}
 
 local_linux_process::local_linux_process(local_linux_process &&other)
     : local_linux_process(other.pid) {
@@ -39,9 +40,11 @@ local_linux_process::~local_linux_process() {
               << "`: " << strerror(errno);
   }
   int status;
-  if (waitpid(pid, &status, 0) == -1)
-    std::cerr << "Error waiting for process (waitpid) `" << pid
-              << "`: " << strerror(errno);
+  if (should_wait) {
+    if (waitpid(pid, &status, 0) == -1)
+      std::cerr << "Error waiting for process (waitpid) `" << pid
+                << "`: " << strerror(errno);
+  }
 }
 
 volatile runner_mailbox *local_linux_process::execute_runner(runner_id_t id) {


### PR DESCRIPTION
## Introduction

This PR introduces support for deep debugging C programs using semaphores, specifically the `sem_init(3)`, `sem_post(3)`, `sem_wait(3)` and `sem_destroy(3)` functions.

### Challenges

Here we encountered a new challenge. `libdmtcp.so` uses semaphores to control user space threads at restart- and checkpoint-time. The checkpoint thread, when signaled by the `dmtcp_coordinator`, will first send the application a `DMTCP_EVENT_PRESUSPEND` event. Afterwards, the checkpoint thread will send a `SIGUSR2` signal to each user space thread (via `pthread_kill(3)`) before sending the application the `DMTCP_EVENT_PRECHECKPOINT`. The user space threads, when signaled, will make a call to `sem_wait(3)`. Once all of the user space threads have called `sem_wait(3)`, it is safe for the checkpoint thread to begin creating the checkpoint image. The motivation is that we do not want user space threads continuing to write to memory while we are copying it out to the checkpoint image. However, since `libmcmini.so` now defines `sem_init(3)`, `sem_post(3)`, `sem_wait(3)` and `sem_destroy(3)`, calls to these functions now end up inside of McMini instead of `libpthread.so`.

#### Solution

For now it suffices to blacklist calls coming from the checkpoint thread. This is accomplished via the new `CHECKPOINT_THEAD` mode visible only to the checkpoint thread. 

A longer-term solution would be to ignore all objects created by the checkpoint thread. Since `libdmtcp.so` acts through the checkpoint thread to control the process and create objects that user space threads use, marking that any such objects should be ignored would be the best solution as it would generalize to other objects. At restart-time, threads will have completed their call to `sem_wait()` first initiated at checkpoint time after being signaled by the checkpoint thread with `SIGUSR2`. These calls will be recorded as they will have come from user space threads, even though they are using objects created by the checkpoint thread. A separate PR will be introduced to add support for ignoring any objects created by the checkpoint thread.

### Running

Using CMake do

```shell
cmake -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j4
```

First create a checkpoint image either directly via `dmtcp_launch` or using `mcmini -i`

```shell
export DURATION=2
dmtcp_launch -i $DURATION --disable-alloc-plugin --modify-env --with-plugin "/path/to/libmcmini.so" ./a.out
```
or
```
mcmini -i $DURATION ./a.out
```

Then with the checkpoint image, run

```
mcmini -mtf --from-checkpoint [chkpt image name] 
```
or
```
mcmini -mtf --from-first-checkpoint
```
if a single checkpoint image exists in the current directory.

A convenience script exists to start a fresh debugging session with McMini and run using `multithreaded-fork(3)`.

```shell
python3 script/debug-mcmini-gdb.py
```

**Note**: If you make changes to `libmcmini.so` source code, make sure to create a new checkpoint image too. If you use an old checkpoint image, the older version of the McMini library will be contained in the checkpoint image.